### PR TITLE
getUniqueID to reject if receives -1

### DIFF
--- a/ovrt-helper.js
+++ b/ovrt-helper.js
@@ -437,6 +437,7 @@ class OVRT {
 	getUniqueID() {
 		return new Promise((resolve) => {
 			const id = window.registerGlobalCallback(this, result => {
+				if(result[0] === -1) return reject();
 				return resolve(result[0]);
 			});
 


### PR DESCRIPTION
Without this, `getUniqueID` promise will hang indefinitely for non-overlays i.e. the wrist view.

Thread for context: https://discord.com/channels/491621961370304513/636655655767375873/888938037151670333