### PR TITLE
Fixed getOverlays return type

### DIFF
--- a/ovrt-helper.js
+++ b/ovrt-helper.js
@@ -445,7 +445,7 @@ class OVRT {
 	getOverlays() {
 		return new Promise((resolve) => {
 			const id = window.registerGlobalCallback(this, result => {
-				return resolve(result[0]);
+				return resolve(JSON.parse(result[0]));
 			});
 
 			this._callAPIFunction("GetOverlays", ["callGlobalCallback", id ]);


### PR DESCRIPTION
getOverlays now returns an array instead of a stringified array