### PR TITLE
Helper fixes

### DIFF
--- a/ovrt-helper.js
+++ b/ovrt-helper.js
@@ -273,7 +273,7 @@ class OVRT {
 		window.addEventListener("overlay-touched", evt => this._emit("overlay-touched", evt));
 		window.addEventListener("device-position", evt => this._emit("device-position", evt));
 		window.addEventListener("interacting", evt => this._emit("interacting", evt));
-		window.addEventListener("overlay-message", evt => this._emit("message", evt));
+		window.addEventListener("overlay-message", evt => this._emit("overlay-message", evt));
 		window.addEventListener("overlay-opened", evt => this._emit("overlay-opened", evt));
 		window.addEventListener("overlay-closed", evt => this._emit("overlay-closed", evt));
 		window.addEventListener("overlay-changed", evt => this._emit("overlay-changed", evt));
@@ -364,21 +364,20 @@ class OVRT {
 	getWindowTitles() {
 		return new Promise((resolve) => {
 			const id = window.registerGlobalCallback(this, result => {
-				// Honestly no idea if this should be parsed? It's a Dictionary in C#.
-				return resolve(result[0]);
+				return resolve(JSON.parse(result[0]));
 			});
 
 			this._callAPIFunction("GetWindowTitles", [ "callGlobalCallback", id ]);
 		});
 	}
 	
-	getMonitorCount() {
+	getMonitorNames() {
 		return new Promise((resolve) => {
 			const id = window.registerGlobalCallback(this, result => {
-				return resolve(result[0]);
+				return resolve(JSON.parse(result[0]));
 			});
 
-			this._callAPIFunction("GetMonitorCount", [ "callGlobalCallback", id ]);
+			this._callAPIFunction("GetMonitorNames", [ "callGlobalCallback", id ]);
 		});
 	}
 	
@@ -526,7 +525,7 @@ class OVRT {
 				return resolve(result[0]); 
 			}); 
  
-			window.GetOverlayBounds("ovrtGetProfileList", ["callGlobalCallback", id ]); 
+			this._callAPIFunction("ovrtGetProfileList", ["callGlobalCallback", id ]); 
 		}); 
 	} 
 	
@@ -536,7 +535,7 @@ class OVRT {
 				return resolve(result[0]); 
 			}); 
  
-			window.GetOverlayBounds("ovrtGetCurrentProfile", ["callGlobalCallback", id ]); 
+			this._callAPIFunction("ovrtGetCurrentProfile", ["callGlobalCallback", id ]); 
 		}); 
 	} 
 	

--- a/ovrt-helper.js
+++ b/ovrt-helper.js
@@ -238,7 +238,7 @@ class OVRTOverlay {
 	}
 	
 	setRenderingEnabled(enable) {
-		window.SetOverlaySetting(`${this._uid}`, 9, !enable);
+		window.SetOverlaySetting(`${this._uid}`, 9, enable);
 	}
 	
 	setInputBlocked(enable) {
@@ -522,7 +522,7 @@ class OVRT {
 	getProfileList() { 
 		return new Promise((resolve) => { 
 			const id = window.registerGlobalCallback(this, result => { 
-				return resolve(result[0]); 
+				return resolve(JSON.parse(result[0])); 
 			}); 
  
 			this._callAPIFunction("ovrtGetProfileList", ["callGlobalCallback", id ]); 


### PR DESCRIPTION
Fixed a number of discrepancies with OVRT API:
- fixed `setRenderingEnabled` being inverted
- renamed the `message` event to `overlay-message` to match OVRT as well as the wiki
- renamed `getMonitorCount` to `getMonitorNames` to match OVRT as well as its actual function
- fixed return types of `getWindowTitles`, `getMonitorNames`, and `getProfileList`
- fixed API calls for `getProfileList` and `getCurrentProfile`