### PR TITLE
Fix setContents not working for desktop capture

### DIFF
--- a/ovrt-helper.js
+++ b/ovrt-helper.js
@@ -144,7 +144,7 @@ class OVRTOverlay {
 	}
 
 	setContent(type, content) {
-		window.SetContents(`${this._uid}`, type, JSON.stringify(content));
+		window.SetContents(`${this._uid}`, type, type==0?JSON.stringify(content):content);//only browser data should be stringified
 	}
 
 	setPosition(x, y, z) {

--- a/ovrt-helper.js
+++ b/ovrt-helper.js
@@ -144,7 +144,7 @@ class OVRTOverlay {
 	}
 
 	setContent(type, content) {
-		window.SetContents(`${this._uid}`, type, type==0?JSON.stringify(content):content);//only browser data should be stringified
+		window.SetContents(`${this._uid}`, type, (type === 0) ? JSON.stringify(content) : content); // only browser data should be stringified
 	}
 
 	setPosition(x, y, z) {


### PR DESCRIPTION
changed setContents to only stringify browser data, since all others are already primitives, (desktop name, window id, or webcam name)